### PR TITLE
Small corrections for typos and configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ These images are part of the bigdata [docker image series](https://github.com/fl
 
 It supports configuration based on environment variables (using specific naming convention), downloaded from consul and other plugins (for example to generate kerberos keystabs).
 
-For more detailed instruction to configure the images see the [README](https://github.com/flokkr/docker-base/blob/master/README.md) in the flokkr/docker-base repository.
+For more detailed instruction to configure the images see the [README](https://github.com/flokkr/docker-baseimage/blob/master/README.md) in the flokkr/docker-base repository.
 
 ## Getting started
 
@@ -12,7 +12,7 @@ For more detailed instruction to configure the images see the [README](https://g
 
 The easiest way to run a storm cluster is just use the included ```docker-compose.yaml``` file. 
 
-Checkout the repository and do a ```docker-compose up -d``` The storm UI will be available at http://localhost:8080
+Checkout the repository and do a ```docker-compose up -d``` The storm UI will be available at http://localhost:8088
 
 You can adjust the settings in the compose-config file.
 
@@ -24,13 +24,18 @@ docker-compose scale datanode=3
 
 To check namenode/resourcemanager use the published ports:
 
-* Resourcemanager: http://localhost:8080
+* Resourcemanager: http://localhost:8088
 * Namenode: http://localhost:50070 (in case of hadoop 2.x)
+
+### FAQ
+
+# Unable to start due to port issues on Windows
+Change port for Host mapping in docker-compose.yaml from 9870 to something else like 3333 (example - 3333:9870).
 
 ### Smoketest
 
 ```
-docker-compose exec resourcemanager /opt/hadoop/bin/yarn jar /opt/hadoop/share/hadoop/mapreduce/hadoop-mapreduce-examples-2.8.1.jar pi 16 1000
+docker-compose exec resourcemanager /opt/hadoop/bin/yarn jar /opt/hadoop/share/hadoop/mapreduce/hadoop-mapreduce-examples-3.2.1.jar pi 16 1000
 
 ### Cluster
 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,6 @@ To check namenode/resourcemanager use the published ports:
 * Resourcemanager: http://localhost:8088
 * Namenode: http://localhost:50070 (in case of hadoop 2.x)
 
-### FAQ
-
-# Unable to start due to port issues on Windows
-Change port for Host mapping in docker-compose.yaml from 9870 to something else like 3333 (example - 3333:9870).
 
 ### Smoketest
 
@@ -51,3 +47,9 @@ There are more detailed examples with using:
 
 
 
+```
+
+## FAQ
+
+### Unable to start due to port issues on Windows
+Change port for Host mapping in docker-compose.yaml from 9870 to something else like 3333 (example - 3333:9870).

--- a/compose-config
+++ b/compose-config
@@ -7,6 +7,9 @@ LOG4J.PROPERTIES_log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 LOG4J.PROPERTIES_log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 LOG4J.PROPERTIES_log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 MAPRED-SITE.XML_mapreduce.framework.name=yarn
+MAPRED-SITE.XML_yarn.app.mapreduce.am.env=HADOOP_MAPRED_HOME=$HADOOP_HOME
+MAPRED-SITE.XML_mapreduce.map.env=HADOOP_MAPRED_HOME=$HADOOP_HOME
+MAPRED-SITE.XML_mapreduce.reduce.env=HADOOP_MAPRED_HOME=$HADOOP_HOME
 YARN-SITE.XML_yarn.resourcemanager.hostname=resourcemanager
 YARN-SITE.XML_yarn.nodemanager.pmem-check-enabled=false
 YARN-SITE.XML_yarn.nodemanager.delete.debug-delay-sec=600


### PR DESCRIPTION
This should fix:
1. #6 in readme
2. Incorporate #4 
3. Fix mapreduce in compose-config variables (new hadoop needs it for running mapreduce jobs) for Smoketest example
4. Add small FAQ section where some additional information can be described.