### PR TITLE
Upgrade Hadoop to 3.3.1

### DIFF
--- a/flokkr.yaml
+++ b/flokkr.yaml
@@ -7,7 +7,7 @@ containers:
    - flokkr/hadoop
 git: https://github.com/flokkr/docker-hadoop
 versions:
-  - 3.3.0
+  - 3.3.1
   - 3.2.2
   - 3.1.4
   - 2.7.3


### PR DESCRIPTION
Build image for recently released 3.3.1 instead of 3.3.0.