### PR TITLE
[fix] failing Yarn test, false negative check result and artifact upload

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,4 +28,4 @@ jobs:
         if: always()
         with:
           name: robot
-          path: test/result
+          path: examples/simple/result

--- a/examples/simple/smoketest/hdfs.robot
+++ b/examples/simple/smoketest/hdfs.robot
@@ -18,7 +18,7 @@ Test HDFS Cli
 
 
 Run Yarn PI job
-  ${output} =      Execute         yarn jar /opt/hadoop/share/hadoop/mapreduce/hadoop-mapreduce-examples-3.2.1.jar pi 10 10
+  ${output} =      Execute         yarn jar /opt/hadoop/share/hadoop/mapreduce/hadoop-mapreduce-examples-*.jar pi 10 10
                    Should Contain  ${output}    Estimated value of Pi is 3.20000000000000000000
 
 *** Keywords

--- a/examples/testlib.sh
+++ b/examples/testlib.sh
@@ -38,8 +38,12 @@ execute_robot_test() {
    set -x
    CONTAINER="$1"
    TEST="$2"
+   rc=0
    kubectl exec "${CONTAINER}" -- bash -c 'rm -rf /tmp/report'
    kubectl exec "${CONTAINER}" -- bash -c 'mkdir -p  /tmp/report'
-   kubectl exec "${CONTAINER}" -- robot -d /tmp/report "${TEST}" || true
+   if ! kubectl exec "${CONTAINER}" -- robot -d /tmp/report "${TEST}"; then
+     rc=1
+   fi
    kubectl cp "${CONTAINER}":/tmp/report/output.xml "${3:-output.xml}" || true
+   return $rc
 }


### PR DESCRIPTION
Yarn PI test is failing due to Hadoop version mismatch:

```
Running command 'yarn jar /opt/hadoop/share/hadoop/mapreduce/hadoop-mapreduce-examples-3.2.1.jar pi 10 10
${rc} = 255
${output} = JAR does not exist or is not a normal file: /opt/hadoop/share/hadoop/mapreduce/hadoop-mapreduce-examples-3.2.1.jar
```

but _test_ workflow is still passing: https://github.com/adoroszlai/docker-hadoop/runs/7052394243#step:7:272
(same code as https://github.com/flokkr/docker-hadoop/runs/3089708518, but logs for that are no longer available).

Also, workflow does not upload test result due to mismatch of paths: `No files were found with the provided path: test/result. No artifacts will be uploaded.`

This PR has the following changes:

  1. Ensure workflow fails in case of test error: https://github.com/adoroszlai/docker-hadoop/runs/7052540407#step:7:290
  2. Fix test result path for artifact upload: https://github.com/adoroszlai/docker-hadoop/actions/runs/2559928513#artifacts
  3. Fix failing test: https://github.com/adoroszlai/docker-hadoop/runs/7052615965#step:7:260